### PR TITLE
Upgrade to NJsonSchema in version 11.0.0

### DIFF
--- a/src/Saunter/AsyncApiOptions.cs
+++ b/src/Saunter/AsyncApiOptions.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+
 using NJsonSchema;
-using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
+
 using Saunter.AsyncApiSchema.v2;
 using Saunter.Generation.Filters;
 using Saunter.Generation.SchemaGeneration;
@@ -85,13 +88,13 @@ namespace Saunter
         public AsyncApiSchemaOptions SchemaOptions { get; set; } = new AsyncApiSchemaOptions();
     }
 
-    public class AsyncApiSchemaOptions : JsonSchemaGeneratorSettings
+    public class AsyncApiSchemaOptions : NewtonsoftJsonSchemaGeneratorSettings
     {
         public AsyncApiSchemaOptions()
         {
             SchemaType = SchemaType.JsonSchema; // AsyncAPI uses json-schema, see https://github.com/tehmantra/saunter/pull/103#issuecomment-893267360
             TypeNameGenerator = new CamelCaseTypeNameGenerator();
-            SerializerSettings = new JsonSerializerSettings
+            SerializerSettings = new JsonSerializerSettings()
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 NullValueHandling = NullValueHandling.Ignore,

--- a/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
+++ b/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Newtonsoft.Json;
-using NJsonSchema.Converters;
+
+using NJsonSchema.NewtonsoftJson.Converters;
 
 namespace Saunter.AsyncApiSchema.v2
 {
@@ -14,7 +16,7 @@ namespace Saunter.AsyncApiSchema.v2
         /// </summary>
         [JsonProperty("asyncapi", NullValueHandling = NullValueHandling.Ignore)]
         public string AsyncApi { get; } = "2.4.0";
-        
+
         /// <summary>
         /// Identifier of the application the AsyncAPI document is defining.
         /// </summary>

--- a/src/Saunter/AsyncApiServiceCollectionExtensions.cs
+++ b/src/Saunter/AsyncApiServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using System;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+
 using Saunter.AsyncApiSchema.v2;
 using Saunter.Generation;
 using Saunter.Serialization;
@@ -14,7 +16,7 @@ namespace Saunter
         /// </summary>
         /// <param name="services">The collection to add services to.</param>
         /// <param name="setupAction">An action used to configure the AsyncAPI options.</param>
-        /// <returns>The service collection so additional calls can be chained.</returns>
+        /// <returns>The service collection so additional calls can b e chained.</returns>
         public static IServiceCollection AddAsyncApiSchemaGeneration(this IServiceCollection services, Action<AsyncApiOptions> setupAction = null)
         {
             services.AddOptions();
@@ -48,7 +50,7 @@ namespace Saunter
                     options.Middleware.UiBaseRoute = "/asyncapi/{document}/ui/";
                 }
 
-                var document = options.NamedApis.GetOrAdd(documentName, _ => new AsyncApiDocument() {DocumentName = documentName});
+                var document = options.NamedApis.GetOrAdd(documentName, _ => new AsyncApiDocument() { DocumentName = documentName });
 
                 setupAction(document);
             });

--- a/src/Saunter/Saunter.csproj
+++ b/src/Saunter/Saunter.csproj
@@ -44,10 +44,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.9.0" />
+    <PackageReference Include="NJsonSchema" Version="11.0.0" />
 
     <!-- Development Dependencies -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Saunter.Tests/Generation/SchemaGeneration/SchemaGenerationTests.cs
+++ b/test/Saunter.Tests/Generation/SchemaGeneration/SchemaGenerationTests.cs
@@ -2,16 +2,23 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+
 using NJsonSchema;
-using NJsonSchema.Converters;
 using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Converters;
+
 using Saunter.AsyncApiSchema.v2;
 using Saunter.Generation.SchemaGeneration;
 using Saunter.Tests.Utils;
+
 using Shouldly;
+
 using Xunit;
+
+using JsonInheritanceAttribute = NJsonSchema.NewtonsoftJson.Converters.JsonInheritanceAttribute;
 
 namespace Saunter.Tests.Generation.SchemaGeneration
 {
@@ -91,7 +98,7 @@ namespace Saunter.Tests.Generation.SchemaGeneration
             var schema = _schemaGenerator.Generate(type, _schemaResolver);
 
             schema.ShouldNotBeNull();
-            
+
             _schemaResolver.Schemas.ShouldNotBeNull();
             var petSchema = _schemaResolver.Schemas.FirstOrDefault(s => s.Id == "pet");
             petSchema.Discriminator.ShouldBe("petType");


### PR DESCRIPTION
* Fixes #179 
* Upgrade to NJsonSchema in version 11.0.0, which decoupled NewtonsoftJson into related NJsonSchema.NewtonsoftJson dependency

Signed-off-by: Tomasz Maruszak <maruszaktomasz@gmail.com>